### PR TITLE
Potential fix for SBA outline incompatibility

### DIFF
--- a/src/main/java/club/sk1er/mods/levelhead/guis/LevelheadMainGUI.java
+++ b/src/main/java/club/sk1er/mods/levelhead/guis/LevelheadMainGUI.java
@@ -1,9 +1,8 @@
 package club.sk1er.mods.levelhead.guis;
 
 import club.sk1er.mods.core.universal.ChatColor;
-import club.sk1er.mods.core.universal.UniversalChat;
-import club.sk1er.mods.core.universal.UniversalDesktop;
-import club.sk1er.mods.core.universal.wrappers.message.UniversalTextComponent;
+import club.sk1er.mods.core.universal.UDesktop;
+import club.sk1er.mods.core.universal.wrappers.message.UTextComponent;
 import club.sk1er.mods.levelhead.Levelhead;
 import club.sk1er.mods.levelhead.display.AboveHeadDisplay;
 import club.sk1er.mods.levelhead.display.ChatDisplay;
@@ -233,7 +232,7 @@ public class LevelheadMainGUI extends GuiScreen implements GuiYesNoCallback {
                     if (isCustom) {
                         mc.displayGuiScreen(new CustomLevelheadConfigurer());
                     } else {
-                        UniversalDesktop.browse(new URI("http://sk1er.club/customlevelhead"));
+                        UDesktop.browse(new URI("http://sk1er.club/customlevelhead"));
                     }
                 } catch (URISyntaxException e) {
                     e.printStackTrace();
@@ -242,7 +241,7 @@ public class LevelheadMainGUI extends GuiScreen implements GuiYesNoCallback {
             });
             reg(new GuiButton(++currentID, 1, 23, 150, 20, YELLOW + "Purchase Levelhead Credits"), button -> {
                 try {
-                    UniversalDesktop.browse(new URI("https://purchase.sk1er.club/category/1050972"));
+                    UDesktop.browse(new URI("https://purchase.sk1er.club/category/1050972"));
                 } catch (URISyntaxException e) {
                     e.printStackTrace();
                 }
@@ -413,8 +412,8 @@ public class LevelheadMainGUI extends GuiScreen implements GuiYesNoCallback {
                     valueIn.setChatStyle(style2);
                     style.setChatHoverEvent(new HoverEvent(HoverEvent.Action.SHOW_TEXT, valueIn));
                     text.setChatStyle(style);
-                    ModCoreAPI.getMinecraftUtil().sendMessage(UniversalTextComponent.from(valueIn).get());
-                    ModCoreAPI.getMinecraftUtil().sendMessage(UniversalTextComponent.from(text).get());
+                    ModCoreAPI.getMinecraftUtil().sendMessage(UTextComponent.Companion.from(valueIn));
+                    ModCoreAPI.getMinecraftUtil().sendMessage(UTextComponent.Companion.from(text));
 
 
                 } catch (UnsupportedEncodingException e2) {

--- a/src/main/java/club/sk1er/mods/levelhead/renderer/LevelheadAboveHeadRender.java
+++ b/src/main/java/club/sk1er/mods/levelhead/renderer/LevelheadAboveHeadRender.java
@@ -43,7 +43,7 @@ public class LevelheadAboveHeadRender {
             return;
         }
         //#if MC<=10809
-        EntityPlayer player = (EntityPlayer)event.entityPlayer;
+        EntityPlayer player = (EntityPlayer)event.entity;
         //#else
         //$$ EntityPlayer player = event.getEntityPlayer();
         //#endif

--- a/src/main/java/club/sk1er/mods/levelhead/renderer/LevelheadAboveHeadRender.java
+++ b/src/main/java/club/sk1er/mods/levelhead/renderer/LevelheadAboveHeadRender.java
@@ -11,7 +11,7 @@ import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.scoreboard.ScoreObjective;
 import net.minecraft.scoreboard.Scoreboard;
-import net.minecraftforge.client.event.RenderPlayerEvent;
+import net.minecraftforge.client.event.RenderLivingEvent;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.modcore.api.ModCoreAPI;
 import org.lwjgl.opengl.GL11;
@@ -32,15 +32,18 @@ public class LevelheadAboveHeadRender {
     }
 
     @SubscribeEvent
-    public void render(RenderPlayerEvent.Pre event) {
+    public void render(RenderLivingEvent.Specials.Pre<EntityLivingBase> event) {
         if (levelhead == null
             || levelhead.getDisplayManager() == null
             || levelhead.getDisplayManager().getMasterConfig() == null
             || !levelhead.getDisplayManager().getMasterConfig().isEnabled()) {
             return;
         }
+        if (!(event.entity instanceof EntityPlayer)) {
+            return;
+        }
         //#if MC<=10809
-        EntityPlayer player = event.entityPlayer;
+        EntityPlayer player = (EntityPlayer)event.entityPlayer;
         //#else
         //$$ EntityPlayer player = event.getEntityPlayer();
         //#endif

--- a/src/main/java/club/sk1er/mods/levelhead/renderer/LevelheadAboveHeadRender.java
+++ b/src/main/java/club/sk1er/mods/levelhead/renderer/LevelheadAboveHeadRender.java
@@ -7,7 +7,9 @@ import net.minecraft.client.gui.FontRenderer;
 import net.minecraft.client.renderer.GlStateManager;
 import net.minecraft.client.renderer.Tessellator;
 import net.minecraft.client.renderer.WorldRenderer;
+import net.minecraft.client.renderer.entity.RenderManager;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
+import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.scoreboard.ScoreObjective;
 import net.minecraft.scoreboard.Scoreboard;
@@ -45,7 +47,7 @@ public class LevelheadAboveHeadRender {
         //#if MC<=10809
         EntityPlayer player = (EntityPlayer)event.entity;
         //#else
-        //$$ EntityPlayer player = event.getEntityPlayer();
+        //$$ EntityPlayer player = (EntityPlayer)event.getEntity();
         //#endif
         int o = 0;
         for (AboveHeadDisplay display : levelhead.getDisplayManager().getAboveHead()) {
@@ -72,9 +74,9 @@ public class LevelheadAboveHeadRender {
                         offset = 0;
                     offset += levelhead.getDisplayManager().getMasterConfig().getOffset();
                     //#if MC<=10809
-                    renderName(event, levelheadTag, player, event.x, event.y + offset + o * .3D, event.z);
+                    renderName(levelheadTag, player, event.x, event.y + offset + o * .3D, event.z);
                     //#else
-                    //$$ renderName(event, levelheadTag, player, event.getX(), event.getY() + offset + o * .3D, event.getZ());
+                    //$$ renderName(levelheadTag, player, event.getX(), event.getY() + offset + o * .3D, event.getZ());
                     //#endif
                 }
             }
@@ -83,11 +85,11 @@ public class LevelheadAboveHeadRender {
 
     }
 
-    public void renderName(RenderPlayerEvent event, LevelheadTag tag, EntityPlayer entityIn, double x, double y, double z) {
+    public void renderName(LevelheadTag tag, EntityPlayer entityIn, double x, double y, double z) {
         //#if MC<=10809
-        FontRenderer fontrenderer = event.renderer.getFontRendererFromRenderManager();
+        FontRenderer fontrenderer = Minecraft.getMinecraft().fontRendererObj;
         //#else
-        //$$ FontRenderer fontrenderer = event.getRenderer().getFontRendererFromRenderManager();
+        //$$ FontRenderer fontrenderer = Minecraft.getMinecraft().fontRenderer;
         //#endif
         float f = (float) (1.6F * Levelhead.getInstance().getDisplayManager().getMasterConfig().getFontSize());
         float f1 = 0.016666668F * f;
@@ -101,11 +103,13 @@ public class LevelheadAboveHeadRender {
         GlStateManager.translate((float) x + 0.0F, (float) y + entityIn.height + 0.5F, (float) z);
         GL11.glNormal3f(0.0F, 1.0F, 0.0F);
         //#if MC<=10809
-        GlStateManager.rotate(-event.renderer.getRenderManager().playerViewY, 0.0F, 1.0F, 0.0F);
-        GlStateManager.rotate(event.renderer.getRenderManager().playerViewX * xMultiplier, 1.0F, 0.0F, 0.0F);
+        RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+        GlStateManager.rotate(-renderManager.playerViewY, 0.0F, 1.0F, 0.0F);
+        GlStateManager.rotate(renderManager.playerViewX * xMultiplier, 1.0F, 0.0F, 0.0F);
         //#else
-        //$$ GlStateManager.rotate(-event.getRenderer().getRenderManager().playerViewY, 0.0F, 1.0F, 0.0F);
-        //$$ GlStateManager.rotate(event.getRenderer().getRenderManager().playerViewX * xMultiplier, 1.0F, 0.0F, 0.0F);
+        //$$ RenderManager renderManager = Minecraft.getMinecraft().getRenderManager();
+        //$$ GlStateManager.rotate(-renderManager.playerViewY, 0.0F, 1.0F, 0.0F);
+        //$$ GlStateManager.rotate(renderManager.playerViewX * xMultiplier, 1.0F, 0.0F, 0.0F);
         //#endif
         GlStateManager.scale(-f1, -f1, f1);
         GlStateManager.disableLighting();


### PR DESCRIPTION
This is untested, but might give a general idea of what I was thinking...
Player nametags aren't rendered when entity outlines are rendered, and that's because (unlike `RenderPlayerEvent.Pre`) the `RenderLivingEvent.Specials` event is not fired when rendering outlines.

I'm not sure if there are gl translate or scaling issues with this modification since I wasn't able to setup my IDE with gradle (I don't have nexus credentials?).